### PR TITLE
XDMA: Mark engine as not running when stopping after timeouts

### DIFF
--- a/XDMA/linux-kernel/libxdma/libxdma.c
+++ b/XDMA/linux-kernel/libxdma/libxdma.c
@@ -558,6 +558,7 @@ static int xdma_engine_stop(struct xdma_engine *engine)
 				(unsigned long)(&engine->regs));
 	/* dummy read of status register to flush all previous writes */
 	dbg_tfr("%s(%s) done\n", __func__, engine->name);
+	engine->running = 0;
 	return 0;
 }
 
@@ -754,7 +755,6 @@ static int engine_service_shutdown(struct xdma_engine *engine)
 		pr_err("Failed to stop engine\n");
 		return rv;
 	}
-	engine->running = 0;
 
 	/* awake task on engine's shutdown wait queue */
 	xlx_wake_up(&engine->shutdown_wq);
@@ -2858,7 +2858,6 @@ struct xdma_transfer *engine_cyclic_stop(struct xdma_engine *engine)
 			pr_err("Failed to stop engine\n");
 			return NULL;
 		}
-		engine->running = 0;
 
 		if (transfer->cyclic) {
 			if (engine->xdma_perf)
@@ -4538,8 +4537,6 @@ void xdma_device_offline(struct pci_dev *pdev, void *dev_hndl)
 			rv = xdma_engine_stop(engine);
 			if (rv < 0)
 				pr_err("Failed to stop engine\n");
-			else
-				engine->running = 0;
 			spin_unlock_irqrestore(&engine->lock, flags);
 		}
 	}
@@ -4555,8 +4552,6 @@ void xdma_device_offline(struct pci_dev *pdev, void *dev_hndl)
 			rv = xdma_engine_stop(engine);
 			if (rv < 0)
 				pr_err("Failed to stop engine\n");
-			else
-				engine->running = 0;
 			spin_unlock_irqrestore(&engine->lock, flags);
 		}
 	}


### PR DESCRIPTION
Unlike engine_start, which sets the engine's running field itself,
engine_stop instead requires its callers to clear the field. However,
not all of them do, and notably the timeout handlers do not, meaning
that after a request times out and we stop the engine we never start it
again, causing all future transfers on the channel to hit the software
timeout.

Instead, set running to 0 inside xdma_engine_stop to mirror engine_start
to both fix the bug and prevent future ones creeping in.